### PR TITLE
ais: remove unneeded libusb inclusion

### DIFF
--- a/ais/rtl_ais.c
+++ b/ais/rtl_ais.c
@@ -39,7 +39,6 @@
 #include <unistd.h>
 
 #include <pthread.h>
-#include <libusb.h>
 
 #include <rtl-sdr.h>
 #include "convenience.h"


### PR DESCRIPTION
Removes the libusb.h header inclusion, which doesn't appear to be needed (at least on OS X - attempted to build, failed with this missing header, removed it and was able to compile successfully with no warnings/errors).