### PR TITLE
label_next does not contain the correct time. use label_time

### DIFF
--- a/heatmap/heatmap.py
+++ b/heatmap/heatmap.py
@@ -596,7 +596,7 @@ def create_labels(args, img):
             if args.compress:
                 y = full_height - time_compression(height - y, args.compress)
             if y - last_y > 15:
-                shadow_text(draw, 2, y+tape_height, label_next.strftime(label_format), font)
+                shadow_text(draw, 2, y+tape_height, label_time.strftime(label_format), font)
                 last_y = y
             label_next += tick_delta
 


### PR DESCRIPTION
While doing multiple hour heatmaps I noticed that the time is way shorter than what I recorded.
Using the label_time for the label shows the correct time in the image.