### PR TITLE
Fix 2 calls deprecated in Py-Pillow 10

### DIFF
--- a/heatmap/heatmap.py
+++ b/heatmap/heatmap.py
@@ -467,12 +467,12 @@ def closest_index(n, m_list, interpolate=False):
 
 def word_aa(label, pt, fg_color, bg_color):
     f = ImageFont.truetype(vera_path, pt*3)
-    s = f.getsize(label)
-    s = (s[0], pt*3 + 3)  # getsize lies, manually compute
+    left, top, right, bottom = f.getbbox(label)
+    s = (right - left, pt*3 + 3)  # getsize lies, manually compute
     w_img = Image.new("RGB", s, bg_color)
     w_draw = ImageDraw.Draw(w_img)
     w_draw.text((0, 0), label, font=f, fill=fg_color)
-    return w_img.resize((s[0]//3, s[1]//3), Image.ANTIALIAS)
+    return w_img.resize((s[0]//3, s[1]//3), Image.Resampling.LANCZOS)
 
 def blend(percent, c1, c2):
     "c1 and c2 are RGB tuples"
@@ -622,4 +622,5 @@ create_labels(args, img)
 
 print("saving")
 img.save(args.output_path)
+
 


### PR DESCRIPTION
2 quick fixes to heatmap.py I had to add for it to work with the latest Pillow.